### PR TITLE
Ensure file descriptors are close-on-exec

### DIFF
--- a/src/kloak.c
+++ b/src/kloak.c
@@ -270,7 +270,7 @@ static char *safe_strdup(const char *s) {
 }
 
 static int safe_open(const char *pathname, int flags) {
-  int out_int = open(pathname, flags);
+  int out_int = open(pathname, flags | O_CLOEXEC);
   if (out_int == -1) {
     fprintf(stderr,
       "FATAL ERROR: Could not open file '%s': %s\n", pathname,
@@ -296,6 +296,17 @@ static DIR *safe_opendir(const char *name, bool allow_enoent) {
       fprintf(stderr,
         "FATAL ERROR: Could not open directory '%s': %s\n", name,
         strerror(errno));
+      exit(1);
+    }
+  } else {
+    int fd = dirfd(out_ptr);
+    if (fd == -1 || fcntl(fd, F_SETFD, FD_CLOEXEC) == -1) {
+      if (fd != -1) {
+        closedir(out_ptr);
+      }
+      fprintf(stderr,
+        "FATAL ERROR: Could not set FD_CLOEXEC on directory '%s': %s\n",
+        name, strerror(errno));
       exit(1);
     }
   }
@@ -385,7 +396,7 @@ static int create_shm_file(ssize_t size) {
     /* 10 = length of 'XXXXXXXXXX', 11 = length + NULL terminator */
     randname(name + sizeof(name) - 11, 10);
     --retries;
-    fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, 0600);
+    fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC, 0600);
     if (fd >= 0) {
       shm_unlink(name);
       break;

--- a/usr/libexec/kloak/find_wl_compositor
+++ b/usr/libexec/kloak/find_wl_compositor
@@ -111,7 +111,10 @@ def query_sock_pid(sock_path: str) -> str | None:
     """
 
     try:
-        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+        with socket.socket(
+            socket.AF_UNIX,
+            socket.SOCK_STREAM | getattr(socket, "SOCK_CLOEXEC", 0),
+        ) as sock:
             sock.settimeout(0.5)
             sock.connect(sock_path)
             struct_fmt: str = "=iII"
@@ -274,7 +277,10 @@ def main() -> NoReturn:
         with os.fdopen(
             os.open(
                 "/run/kloak_wl_compositor_data",
-                os.O_RDWR | os.O_CREAT | os.O_TRUNC,
+                os.O_RDWR
+                | os.O_CREAT
+                | os.O_TRUNC
+                | getattr(os, "O_CLOEXEC", 0),
                 mode=0o600,
             ),
             "r+",


### PR DESCRIPTION
## Summary
- Add `O_CLOEXEC` to `safe_open` and `shm_open` wrappers
- Enforce `FD_CLOEXEC` on directories opened via `safe_opendir`
- Use close-on-exec flags for Python helper's socket and output file

## Testing
- `make all` *(fails: wayland-scanner: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c53fdda8d48320a2618aabdaa99be2