### PR TITLE
Check allocation overflow in safe_calloc

### DIFF
--- a/src/kloak.c
+++ b/src/kloak.c
@@ -240,6 +240,11 @@ static struct key_name_value key_table[] = {
 /*********************/
 
 static void *safe_calloc(size_t nmemb, size_t size) {
+  if (nmemb != 0 && size > SIZE_MAX / nmemb) {
+    fprintf(stderr,
+      "FATAL ERROR: Requested allocation size would overflow\n");
+    exit(1);
+  }
   void *out_ptr = calloc(nmemb, size);
   if (out_ptr == NULL) {
     fprintf(stderr,


### PR DESCRIPTION
## Summary
- guard safe_calloc against multiplication overflow before calling calloc

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68c5444ca51483209d2a41c33eca682e